### PR TITLE
Restrict user signup email domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
   </a>
 </h3>
 <p align="center">
-  <a href="https://github.com/fastlane/deliver">deliver</a> &bull; 
-  <a href="https://github.com/fastlane/snapshot">snapshot</a> &bull; 
-  <a href="https://github.com/fastlane/frameit">frameit</a> &bull; 
-  <a href="https://github.com/fastlane/PEM">PEM</a> &bull; 
-  <a href="https://github.com/fastlane/sigh">sigh</a> &bull; 
+  <a href="https://github.com/fastlane/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/frameit">frameit</a> &bull;
+  <a href="https://github.com/fastlane/PEM">PEM</a> &bull;
+  <a href="https://github.com/fastlane/sigh">sigh</a> &bull;
   <a href="https://github.com/fastlane/produce">produce</a> &bull;
   <a href="https://github.com/fastlane/cert">cert</a> &bull;
   <a href="https://github.com/fastlane/spaceship">spaceship</a> &bull;
@@ -76,7 +76,7 @@ Assuming you already have a [Heroku](https://www.heroku.com/) account follow tho
 
 `boarding` does all kinds of magic for you, like fetching the app name and app icon.
 
-Heroku is free to use for the standard machine. If you need a Heroku account, ask your back-end team if you already have a company account. 
+Heroku is free to use for the standard machine. If you need a Heroku account, ask your back-end team if you already have a company account.
 
 ---
 
@@ -86,7 +86,7 @@ Heroku is free to use for the standard machine. If you need a Heroku account, as
 
 ## Security
 
-To secure your webpage, you only have to set the `ITC_TOKEN` environment variable to any password. 
+To secure your webpage, you only have to set the `ITC_TOKEN` environment variable to any password.
 
 - You can send your users the link and tell them the password
 - You can send them the direct link including the token like this: https://url.com/?token=[password]
@@ -102,6 +102,7 @@ To secure your webpage, you only have to set the `ITC_TOKEN` environment variabl
 **Optional:**
 - `ITC_TOKEN` Set a password to protect your website from random people signing up
 - `ITC_CLOSED_TEXT` Set this text to temporary disable enrollment of new beta testers
+- `RESTRICTED_DOMAIN` Set this domain (in the format `domain.com`) to restrict users with emails in another domain from signing up
 
 ## Custom Domain
 
@@ -109,7 +110,7 @@ With Heroku you can easily use your own domain, follow [this guide](https://devc
 
 # How does this work?
 
-`boarding` is part of [fastlane](https://fastlane.tools), which helps you automate everything you usually do manually as an iOS developer. 
+`boarding` is part of [fastlane](https://fastlane.tools), which helps you automate everything you usually do manually as an iOS developer.
 
 Using [spaceship.airforce](https://spaceship.airforce) it is possible to manage testers, builds, metadata, certificates and so much more.
 

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -20,6 +20,15 @@ class InviteController < ApplicationController
     first_name = params[:first_name]
     last_name = params[:last_name]
 
+    if ENV["RESTRICTED_DOMAIN"]
+      if email.split("@").last != ENV["RESTRICTED_DOMAIN"]
+        @message = "Sorry! Early access is currently restricted to people within the #{ENV["RESTRICTED_DOMAIN"]} domain.  We will be opening it up soon, though!"
+        @type = "warning"
+        render :index
+        return
+      end
+    end
+
     if ENV["ITC_TOKEN"]
       if ENV["ITC_TOKEN"] != params[:token]
         @message = t(:message_invalid_password)
@@ -50,8 +59,8 @@ class InviteController < ApplicationController
       tester ||= Spaceship::Tunes::Tester::External.find(config[:email])
       Helper.log.info "Existing tester #{tester.email}".green if tester
 
-      tester ||= Spaceship::Tunes::Tester::External.create!(email: email, 
-                                                            first_name: first_name, 
+      tester ||= Spaceship::Tunes::Tester::External.create!(email: email,
+                                                            first_name: first_name,
                                                             last_name: last_name)
 
       logger.info "Successfully created tester #{tester.email}"
@@ -95,7 +104,7 @@ class InviteController < ApplicationController
 
     def apple_id
       Rails.logger.error "No app to add this tester to provided, use the `ITC_APP_ID` environment variable" unless ENV["ITC_APP_ID"]
-      
+
       Rails.cache.fetch('AppID', expires_in: 10.minutes) do
         if ENV["ITC_APP_ID"].include?"." # app identifier
           login

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -22,7 +22,7 @@ class InviteController < ApplicationController
 
     if ENV["RESTRICTED_DOMAIN"]
       if email.split("@").last != ENV["RESTRICTED_DOMAIN"]
-        @message = "Sorry! Early access is currently restricted to people within the #{ENV["RESTRICTED_DOMAIN"]} domain.  We will be opening it up soon, though!"
+        @message = "Sorry! Early access is currently restricted to people within the #{ENV["RESTRICTED_DOMAIN"]} domain."
         @type = "warning"
         render :index
         return


### PR DESCRIPTION
As per discussion in #42, this adds (and documents) the ability to restrict the email domain from with which users can sign up.