### PR TITLE
Enable Boarding to be served from a non-root URL

### DIFF
--- a/app/views/invite/index.html.erb
+++ b/app/views/invite/index.html.erb
@@ -24,7 +24,7 @@
   <% unless @message %>
     <h4 class="" style="margin-bottom: 40px;"><%= @metadata[:title] %></h4>
 
-    <%= form_tag("/submit", method: "post", style: "text-align: left") do %>
+    <%= form_tag("submit", method: "post", style: "text-align: left") do %>
       <%= label_tag(:first_name, t(:first_name_label)) %>
       <%= text_field_tag :first_name, '', class: "form-control", placeholder: t(:first_name_placeholder) %><br />
       <%= label_tag(:last_name, t(:last_name_label)) %>


### PR DESCRIPTION
Made the submit route URL relative so that Boarding can be served from non-root URLs (e.g., something like https://ind.ie/beta/boarding)

Boarding can be served from non-root URLs by setting the `RAILS_RELATIVE_URL_ROOT` environment variable. e.g., (`RAILS_RELATIVE_URL_ROOT=/beta/boarding), however, the submit route triggered by the Get Beta Access button fails as it is specified from root as `/submit`. This pull request makes the route relative (`submit`) so that serving Boarding from non-root URLs works.

(I’ve successfully installed and run Boarding from my own Dokku instance, served via an nginx reverse proxy and this was the only change I needed to make. I’m in the process of documenting the process in a short post that I will publish shortly.)