### PR TITLE
Changed a way to check that user with given e-mail is in iTunes Testers.

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -55,8 +55,8 @@ class InviteController < ApplicationController
     begin
       login
 
-      tester = Spaceship::Tunes::Tester::Internal.find(config[:email])
-      tester ||= Spaceship::Tunes::Tester::External.find(config[:email])
+      tester = Spaceship::Tunes::Tester::Internal.find(email)
+      tester ||= Spaceship::Tunes::Tester::External.find(email)
       logger.info "Existing tester #{tester.email}" if tester
 
       tester ||= Spaceship::Tunes::Tester::External.create!(email: email,


### PR DESCRIPTION
I not an ruby master, but without this change, version from HEAD don't create new users. As far I understand, we are checking that user with given email is present in iTunes Connect Testers, but instead use `params[:email]` or simply `email` we are using `config[:email]` which is empty and this return us account owner account?