### PR TITLE
Use absolute paths for README images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h3 align="center">
   <a href="https://github.com/fastlane/fastlane">
-    <img src="app/assets/images/fastlane.png" width="100" />
+    <img src="https://raw.githubusercontent.com/fastlane/boarding/master/app/assets/images/fastlane.png" width="100" />
     <br />
     fastlane
   </a>
@@ -22,7 +22,7 @@
 -------
 
 <p align="center">
-  <img src="assets/BoardingHuge.png" width="650">
+  <img src="https://raw.githubusercontent.com/fastlane/boarding/master/assets/BoardingHuge.png" width="650">
 </p>
 -------
 
@@ -56,7 +56,7 @@ Because that's what you do right now as an app developer when you want to add a 
 
 Why don't you have a simple web site you can share with potential testers (e.g. email newsletter, Facebook, Twitter) on which people interested in trying out your new app can just `board` on their own?
 
-![BoardingScreenshot](assets/BoardingScreenshot.png)
+![BoardingScreenshot](https://raw.githubusercontent.com/fastlane/boarding/master/assets/BoardingScreenshot.png)
 
 Thanks to [spaceship.airforce](https://spaceship.airforce) (oh well, I really talk a lot about flying :rocket:) it is now possible to automate the boarding process for your TestFlight beta testers.
 
@@ -80,7 +80,7 @@ Heroku is free to use for the standard machine. If you need a Heroku account, as
 
 ---
 
-![SetupGif](assets/BoardingSetup.gif)
+![SetupGif](https://raw.githubusercontent.com/fastlane/boarding/master/assets/BoardingSetup.gif)
 
 ---
 
@@ -122,7 +122,7 @@ This repository is a simple Rails application with most code in these files:
 - [invite_controller.rb](https://github.com/fastlane/boarding/blob/master/app/controllers/invite_controller.rb)
 - [invite/index.html.erb](https://github.com/fastlane/boarding/blob/master/app/views/invite/index.html.erb)
 
-![BoardingOverview](assets/BoardingOverview.png)
+![BoardingOverview](https://raw.githubusercontent.com/fastlane/boarding/master/assets/BoardingOverview.png)
 
 More information about this automation process can be found [here](https://krausefx.com/blog/letting-computers-do-the-hard-work).
 


### PR DESCRIPTION
Hi fastlane team-  We're considering featuring boarding in the Heroku August monthly newsletter as the "Button of the Month" (e.g. https://cl.ly/h1xS), and I'm wondering if you're ok making these URL path changes in this repo's README.

We have a [gallery page on heroku.com that renders the README](https://elements.heroku.com/buttons/fastlane/boarding) and the images for this repo are showing up broken.  I'm pretty sure this is an issue on our side in how we render the README, but I'm not sure if that issue will get fixed in time for the newsletter.

This PR changes the paths for images in the README to absolute paths on GitHub instead of relative paths.  I actually think your relative path implementation is better, but if you could make this change it would provide a better experience for newsletter readers wanting to check out boarding.

Thanks!

-Chris