### PR TITLE
Fixes issue where boarding requires an admin user

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -89,7 +89,7 @@ class InviteController < ApplicationController
         end
         @type = "success"
       end
-
+      
     rescue => ex
       Rails.logger.fatal ex.inspect
       Rails.logger.fatal ex.backtrace.join("\n")
@@ -102,74 +102,74 @@ class InviteController < ApplicationController
   end
 
   private
-  def user
-    ENV["ITC_USER"] || ENV["FASTLANE_USER"]
-  end
-
-  def password
-    ENV["ITC_PASSWORD"] || ENV["FASTLANE_PASSWORD"]
-  end
-
-  def apple_id
-    Rails.logger.error "No app to add this tester to provided, use the `ITC_APP_ID` environment variable" unless ENV["ITC_APP_ID"]
-
-    Rails.cache.fetch('AppID', expires_in: 10.minutes) do
-      if ENV["ITC_APP_ID"].include?"." # app identifier
-        login
-        app = Spaceship::Application.find(ENV["ITC_APP_ID"])
-        app.apple_id
-      else
-        ENV["ITC_APP_ID"].to_s
-      end
+    def user
+      ENV["ITC_USER"] || ENV["FASTLANE_USER"]
     end
-  end
 
-  def app
-    login
-
-    @app ||= Spaceship::Tunes::Application.find(ENV["ITC_APP_ID"])
-
-    raise "Could not find app with ID #{apple_id}" unless @app
-
-    @app
-  end
-
-  def app_metadata
-    Rails.cache.fetch('appMetadata', expires_in: 10.minutes) do
-      {
-        icon_url: app.app_icon_preview_url,
-        title: app.name
-      }
+    def password
+      ENV["ITC_PASSWORD"] || ENV["FASTLANE_PASSWORD"]
     end
-  end
 
-  def login
-    return if @spaceship
-    @spaceship = Spaceship::Tunes.login(user, password)
-    @spaceship.select_team
-  end
+    def apple_id
+      Rails.logger.error "No app to add this tester to provided, use the `ITC_APP_ID` environment variable" unless ENV["ITC_APP_ID"]
 
-  def set_app_details
-    @metadata = app_metadata
-    @title = @metadata[:title]
-  end
-
-  def check_disabled_text
-    if ENV["ITC_CLOSED_TEXT"]
-      @message = ENV["ITC_CLOSED_TEXT"]
-      @type = "warning"
-    end
-  end
-
-  # @return [Boolean] Is at least one TestFlight beta testing build available?
-  def testing_is_live?
-    app.build_trains.each do |version, train|
-      if train.external_testing_enabled
-        train.builds.each do |build|
-          return true if build.external_testing_enabled
+      Rails.cache.fetch('AppID', expires_in: 10.minutes) do
+        if ENV["ITC_APP_ID"].include?"." # app identifier
+          login
+          app = Spaceship::Application.find(ENV["ITC_APP_ID"])
+          app.apple_id
+        else
+          ENV["ITC_APP_ID"].to_s
         end
       end
     end
-    return false
-  end
+
+    def app
+      login
+
+      @app ||= Spaceship::Tunes::Application.find(ENV["ITC_APP_ID"])
+
+      raise "Could not find app with ID #{apple_id}" unless @app
+
+      @app
+    end
+
+    def app_metadata
+      Rails.cache.fetch('appMetadata', expires_in: 10.minutes) do
+        {
+          icon_url: app.app_icon_preview_url,
+          title: app.name
+        }
+      end
+    end
+
+    def login
+      return if @spaceship
+      @spaceship = Spaceship::Tunes.login(user, password)
+      @spaceship.select_team
+    end
+
+    def set_app_details
+      @metadata = app_metadata
+      @title = @metadata[:title]
+    end
+
+    def check_disabled_text
+      if ENV["ITC_CLOSED_TEXT"]
+        @message = ENV["ITC_CLOSED_TEXT"]
+        @type = "warning"
+      end
+    end
+
+    # @return [Boolean] Is at least one TestFlight beta testing build available?
+    def testing_is_live?
+      app.build_trains.each do |version, train|
+        if train.external_testing_enabled
+          train.builds.each do |build|
+            return true if build.external_testing_enabled
+          end
+        end
+      end
+      return false
+    end
 end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -60,7 +60,7 @@ class InviteController < ApplicationController
     begin
       login
 
-      tester = Spaceship::Tunes::Tester::External.find_by_app(apple_id)
+      tester = Spaceship::Tunes::Tester::External.find_by_app(apple_id, email)
 
       if tester
         @message = t(:message_email_exists)

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -60,6 +60,14 @@ class InviteController < ApplicationController
     begin
       login
 
+      tester = Spaceship::Tunes::Tester::External.find_by_app(apple_id)
+
+      if tester
+        @message = t(:message_email_exists)
+        @type = "danger"
+        return
+      end
+
       # This works even if the tester already exists
       tester = Spaceship::Tunes::Tester::External.new({
         'emailAddress' => {'value' => email},

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -67,29 +67,29 @@ class InviteController < ApplicationController
       if tester
         @message = t(:message_email_exists)
         @type = "danger"
-        return
-      end
-
-      tester = Spaceship::Tunes::Tester::External.new({
-        'emailAddress' => {'value' => email},
-        'firstName' => {'value' => first_name},
-        'lastName' => {'value' => last_name}
-      })
-
-      logger.info "Successfully created tester #{tester.email}"
-
-      if apple_id.length > 0
-        logger.info "Addding tester to application"
-        tester.add_to_app!(apple_id)
-        logger.info "Done"
-      end
-
-      if testing_is_live?
-        @message = t(:message_success_live)
       else
-        @message = t(:message_success_pending)
+        tester = Spaceship::Tunes::Tester::External.new({
+          'emailAddress' => {'value' => email},
+          'firstName' => {'value' => first_name},
+          'lastName' => {'value' => last_name}
+        })
+
+        logger.info "Successfully created tester #{tester.email}"
+
+        if apple_id.length > 0
+          logger.info "Addding tester to application"
+          tester.add_to_app!(apple_id)
+          logger.info "Done"
+        end
+
+        if testing_is_live?
+          @message = t(:message_success_live)
+        else
+          @message = t(:message_success_pending)
+        end
+        @type = "success"
       end
-      @type = "success"
+
     rescue => ex
       Rails.logger.fatal ex.inspect
       Rails.logger.fatal ex.backtrace.join("\n")
@@ -102,74 +102,74 @@ class InviteController < ApplicationController
   end
 
   private
-    def user
-      ENV["ITC_USER"] || ENV["FASTLANE_USER"]
+  def user
+    ENV["ITC_USER"] || ENV["FASTLANE_USER"]
+  end
+
+  def password
+    ENV["ITC_PASSWORD"] || ENV["FASTLANE_PASSWORD"]
+  end
+
+  def apple_id
+    Rails.logger.error "No app to add this tester to provided, use the `ITC_APP_ID` environment variable" unless ENV["ITC_APP_ID"]
+
+    Rails.cache.fetch('AppID', expires_in: 10.minutes) do
+      if ENV["ITC_APP_ID"].include?"." # app identifier
+        login
+        app = Spaceship::Application.find(ENV["ITC_APP_ID"])
+        app.apple_id
+      else
+        ENV["ITC_APP_ID"].to_s
+      end
     end
+  end
 
-    def password
-      ENV["ITC_PASSWORD"] || ENV["FASTLANE_PASSWORD"]
+  def app
+    login
+
+    @app ||= Spaceship::Tunes::Application.find(ENV["ITC_APP_ID"])
+
+    raise "Could not find app with ID #{apple_id}" unless @app
+
+    @app
+  end
+
+  def app_metadata
+    Rails.cache.fetch('appMetadata', expires_in: 10.minutes) do
+      {
+        icon_url: app.app_icon_preview_url,
+        title: app.name
+      }
     end
+  end
 
-    def apple_id
-      Rails.logger.error "No app to add this tester to provided, use the `ITC_APP_ID` environment variable" unless ENV["ITC_APP_ID"]
+  def login
+    return if @spaceship
+    @spaceship = Spaceship::Tunes.login(user, password)
+    @spaceship.select_team
+  end
 
-      Rails.cache.fetch('AppID', expires_in: 10.minutes) do
-        if ENV["ITC_APP_ID"].include?"." # app identifier
-          login
-          app = Spaceship::Application.find(ENV["ITC_APP_ID"])
-          app.apple_id
-        else
-          ENV["ITC_APP_ID"].to_s
+  def set_app_details
+    @metadata = app_metadata
+    @title = @metadata[:title]
+  end
+
+  def check_disabled_text
+    if ENV["ITC_CLOSED_TEXT"]
+      @message = ENV["ITC_CLOSED_TEXT"]
+      @type = "warning"
+    end
+  end
+
+  # @return [Boolean] Is at least one TestFlight beta testing build available?
+  def testing_is_live?
+    app.build_trains.each do |version, train|
+      if train.external_testing_enabled
+        train.builds.each do |build|
+          return true if build.external_testing_enabled
         end
       end
     end
-
-    def app
-      login
-
-      @app ||= Spaceship::Tunes::Application.find(ENV["ITC_APP_ID"])
-
-      raise "Could not find app with ID #{apple_id}" unless @app
-
-      @app
-    end
-
-    def app_metadata
-      Rails.cache.fetch('appMetadata', expires_in: 10.minutes) do
-        {
-          icon_url: app.app_icon_preview_url,
-          title: app.name
-        }
-      end
-    end
-
-    def login
-      return if @spaceship
-      @spaceship = Spaceship::Tunes.login(user, password)
-      @spaceship.select_team
-    end
-
-    def set_app_details
-      @metadata = app_metadata
-      @title = @metadata[:title]
-    end
-
-    def check_disabled_text
-      if ENV["ITC_CLOSED_TEXT"]
-        @message = ENV["ITC_CLOSED_TEXT"]
-        @type = "warning"
-      end
-    end
-
-    # @return [Boolean] Is at least one TestFlight beta testing build available?
-    def testing_is_live?
-      app.build_trains.each do |version, train|
-        if train.external_testing_enabled
-          train.builds.each do |build|
-            return true if build.external_testing_enabled
-          end
-        end
-      end
-      return false
-    end
+    return false
+  end
 end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -62,18 +62,19 @@ class InviteController < ApplicationController
 
       tester = Spaceship::Tunes::Tester::External.find_by_app(apple_id, email)
 
+      logger.info "Found tester #{tester}"
+
       if tester
         @message = t(:message_email_exists)
         @type = "danger"
         return
       end
 
-      # This works even if the tester already exists
       tester = Spaceship::Tunes::Tester::External.new({
         'emailAddress' => {'value' => email},
         'firstName' => {'value' => first_name},
         'lastName' => {'value' => last_name}
-        })
+      })
 
       logger.info "Successfully created tester #{tester.email}"
 
@@ -90,16 +91,11 @@ class InviteController < ApplicationController
       end
       @type = "success"
     rescue => ex
-      if ex.inspect.to_s.include?"EmailExists"
-        @message = t(:message_email_exists)
-        @type = "danger"
-      else
-        Rails.logger.fatal ex.inspect
-        Rails.logger.fatal ex.backtrace.join("\n")
+      Rails.logger.fatal ex.inspect
+      Rails.logger.fatal ex.backtrace.join("\n")
 
-        @message = t(:message_error)
-        @type = "danger"
-      end
+      @message = t(:message_error)
+      @type = "danger"
     end
 
     render :index

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -60,13 +60,12 @@ class InviteController < ApplicationController
     begin
       login
 
-      tester = Spaceship::Tunes::Tester::Internal.find(email)
-      tester ||= Spaceship::Tunes::Tester::External.find(email)
-      logger.info "Existing tester #{tester.email}" if tester
-
-      tester ||= Spaceship::Tunes::Tester::External.create!(email: email,
-                                                            first_name: first_name,
-                                                            last_name: last_name)
+      # This works even if the tester already exists
+      tester = Spaceship::Tunes::Tester::External.new({
+        'emailAddress' => {'value' => email},
+        'firstName' => {'value' => first_name},
+        'lastName' => {'value' => last_name}
+        })
 
       logger.info "Successfully created tester #{tester.email}"
 


### PR DESCRIPTION
App Manager users can only access external tester details for a specific app, they cannot query or manage overall external testers for the team.

This seems to work for me with an App Manager user.

Fixes issues #53 & #65 