### PR TITLE
Fix form for Safari when it's in iframe

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -2,6 +2,8 @@ class InviteController < ApplicationController
   before_action :set_app_details
   before_action :check_disabled_text
 
+  skip_before_filter :verify_authenticity_token
+
   def index
     if user and password
       # default


### PR DESCRIPTION
Fixes https://github.com/fastlane/boarding/issues/59

Since there is no kind of auth in boarding, skipping the csrf filter shouldn't cause any security issues.