### PR TITLE
Add an optional cap for the number of testers

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -72,6 +72,16 @@ class InviteController < ApplicationController
     begin
       login
 
+      if ENV['MAX_NUMBER_OF_TESTERS']
+          if ENV['MAX_NUMBER_OF_TESTERS'].to_i <= Spaceship::Tunes::Tester::External.all.count
+              @message = t(:message_max_testers)
+              @type = 'warning'
+              render :index
+              #ENV['ITC_CLOSED_TEXT'] = t(:message_max_testers)
+              return
+          end
+      end
+
       tester = Spaceship::Tunes::Tester::External.find_by_app(apple_id, email)
 
       logger.info "Found tester #{tester}"
@@ -101,7 +111,7 @@ class InviteController < ApplicationController
         end
         @type = "success"
       end
-      
+
     rescue => ex
       Rails.logger.fatal ex.inspect
       Rails.logger.fatal ex.backtrace.join("\n")

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -30,6 +30,7 @@ cs:
   password_placeholder: "Heslo"
   get_beta_access: "Získat přístup k beta verzi"
   message_invalid_password: "Neplatné heslo, kontaktujte prosím provozovatele aplikace"
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_demo_page: "Toto je demo stránka. Tady by byla potvrzující zpráva s informacemi o TestFlight emailu"
   message_success_live: "Byl jste úspěšně přidán jako tester. Zkontrolujte svou emailovou schránku kvůli pozvánce"
   message_success_pending: "Byl jste úspěšně přidán jako tester. Budeme Vás informovat, jakmile bude k dispozici další testovací verze"

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -30,6 +30,7 @@ da:
   password_placeholder: "Kodeord"
   get_beta_access: "Få Beta Adgang"
   message_invalid_password: "Forkert kodeord, kontakt venligst app ejeren"
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_demo_page: "Dette er en test side. Her kommer success beskeden med information om TestFlight e-mailen"
   message_success_live: "Du er blevet tilføjet som tester. Tjek din e-mail for invitationen"
   message_success_pending: "Du er blevet tilføjet som tester. Du får besked når næste version er tilgængelig"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -30,6 +30,7 @@ de:
   password_placeholder: "Passwort"
   get_beta_access: "Beta-Zugang anfordern"
   message_invalid_password: "Ungültiges Passwort, bitte kontaktieren Sie den Hersteller der Applikation"
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_demo_page: "Dies ist eine Demoseite. Hier würde die Bestätigung mit Informationen über die TestFlight E-Mail stehen"
   message_success_live: "Sie wurden erfolgreich als Tester hinzugefügt. Überprüfen Sie Ihren Posteingang für eine Einladung"
   message_success_pending: "Sie wurden erfolgreich als Tester hinzugefügt. Sie werden benachrichtigt sobald eine neue Version verfügbar ist"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
   password_placeholder: "Password"
   get_beta_access: "Get Beta Access"
   message_invalid_password: "Invalid password given, please contact the application owner"
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_demo_page: "This is a demo page. Here would be the success message with information about the TestFlight email"
   message_success_live: "Successfully added you as a tester. Check your email inbox for an invite"
   message_success_pending: "Successfully added you as a tester. You'll be notified once the next build is available"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -30,6 +30,7 @@ es:
   password_placeholder: "Contraseña"
   get_beta_access: "Acceder a la beta"
   message_invalid_password: "Contraseña incorrecta, por favor contacta con el propietario de la aplicación"
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_demo_page: "Esto es una página de prueba.  Aquí tendrías el mensaje de éxito con la información sobre el correo electrónico de TestFlight"
   message_success_live: "Has sido añadido como tester. Revisa tu correo para ver la invitación"
   message_success_pending: "Has sido añadido como tester. Se te avisará una vez que la próxima versión esté disponible"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -30,6 +30,7 @@ fr:
   password_placeholder: "Mot de passe"
   get_beta_access: "Accéder à la beta"
   message_invalid_password: "Le mot de passe est invalide. Veuillez contacter le développeur de l'application."
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_demo_page: "Ceci est une page de démonstration. Voici à quoi ressemblerait le message à propos de l'e-mail TestFlight."
   message_success_live: "Vous avez bien été enregistré en tant que testeur. Une invitation vous a été envoyée, veuillez relever votre boîte e-mail."
   message_success_pending: "Vous avez bien été enregistré en tant que testeur. Vous serez averti par e-mail lorsque l'application sera disponible."

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -30,6 +30,7 @@ it:
   password_placeholder: "Password"
   get_beta_access: "Ottieni l'accesso beta"
   message_invalid_password: "Password invalida, per favore contatta il proprietario dell'applicazione"
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_demo_page: "Questa è una pagina di esempio. Qui ci sarebbe il messaggio di conferma con le informazioni riguardo l'email di TestFlight"
   message_success_live: "Sei stato aggiunto come tester. Controlla la tua mail per l'invito"
   message_success_pending: "Sei stato aggiunto come tester. Sarai avvisato quando la prossima build sarà disponibile"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -30,6 +30,7 @@ ru:
   password_placeholder: "Пароль"
   get_beta_access: "Получить доступ к beta-версии."
   message_invalid_password: "Неверный пароль. Пожалуйста, свяжитесь с разработчиком приложения."
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_demo_page: "Это демо-страница. Здесь будет сообщение с информацией о письме от TestFlight."
   message_success_live: "Вы успешно добавлены в программу beta-тестирования. Вам на почту придет приглашение."
   message_success_pending: "Вы успешно добавлены в программу beta-тестирования. Вам придет уведомление, как только следующая beta-версия приложения станет доступна."

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -31,6 +31,7 @@ zh-TW:
   get_beta_access: "取得測試邀請"
   message_invalid_password: "錯誤的密碼，請聯繫程式作者"
   message_demo_page: "這是一個測試頁面，這邊將會有成功訊息與關於 TestFlight 邀請信的相關資訊。"
+  message_max_testers: "Maximum number of testers has been reached, please check back later"
   message_success_live: "已經成功將你加為測試者，請確認信箱中的邀請函。"
   message_success_pending: "已經成功將你加為測試者，你將在下次新版釋出時收到通知。"
   message_email_exists: "Email 已經被註冊"


### PR DESCRIPTION
I've found its nice to limit the number of testers to 500. This allows us to keep some slots reserved for the future.