### PR TITLE
Bumping spaceship version to 0.38.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
 
 # Added by Felix
-gem 'spaceship', '>= 0.32.1'
+gem 'spaceship', '>= 0.38.4'
 
 gem 'bootstrap-sass', '~> 3.3.5'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     arel (6.0.3)
     autoprefixer-rails (6.5.3)
       execjs
+    babosa (1.0.2)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.7)
@@ -64,7 +65,7 @@ GEM
       highline (>= 1.7.1)
       security
     debug_inspector (0.0.2)
-    domain_name (0.5.20161021)
+    domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -145,7 +146,8 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     security (0.1.3)
-    spaceship (0.37.0)
+    spaceship (0.38.4)
+      babosa (= 1.0.2)
       colored
       credentials_manager (>= 0.16.0)
       faraday (~> 0.9)
@@ -192,10 +194,10 @@ DEPENDENCIES
   rails (= 4.2.1)
   rails_12factor
   sass-rails (~> 5.0)
-  spaceship (>= 0.32.1)
+  spaceship (>= 0.38.4)
   spring
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.13.3
+   1.13.6


### PR DESCRIPTION
I faced an issue with having older version of Spaceship in Heroku app logs.
