### PR TITLE
Updated Spaceship to 0.38.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
 
 # Added by Felix
-gem 'spaceship', '>= 0.38.4'
+gem 'spaceship', '>= 0.38.5'
 
 gem 'bootstrap-sass', '~> 3.3.5'
 


### PR DESCRIPTION
Spaceship had an issue when connecting with iTunesConnect, causing Boarding to crash. This error has been resolved in Spaceship and resolves the issue in Boarding. A working app with the update can be found at https://join-crowd-signup.herokuapp.com/.