### PR TITLE
Add zh-CN localization

### DIFF
--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,0 +1,37 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
+
+zh-CN:
+  first_name_label: "名字："
+  first_name_placeholder: "名字"
+  last_name_label: "姓氏："
+  last_name_placeholder: "姓氏"
+  email_label: "电子邮箱："
+  email_placeholder: "电子邮箱"
+  password_label: "密码："
+  password_placeholder: "密码"
+  get_beta_access: "申请加入测试"
+  message_invalid_password: "密码错误，请联系管理员"
+  message_demo_page: "这是一个测试页面，这里将会有成功提示和 TestFlight 邮件的相关信息"
+  message_success_live: "您已成为测试员，请确认电子邮箱中的邀请函"
+  message_success_pending: "您已成为测试员，您会在新的测试版本推出时收到邮件通知"
+  message_email_exists: "电子邮箱已被注册"
+  message_error: "出现了错误，请联系管理员"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -20,10 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 zh-TW:
-  first_name_label: "姓："
-  first_name_placeholder: "姓"
-  last_name_label: "名："
-  last_name_placeholder: "名"
+  first_name_label: "名："
+  first_name_placeholder: "名"
+  last_name_label: "姓："
+  last_name_placeholder: "姓"
   email_label: "Email 地址："
   email_placeholder: "Email 地址"
   password_label: "密碼："


### PR DESCRIPTION
Also correct an error in `zh-TW.yml`. In Chinese, the first name is actually the given name (名) while the last name is actually the family name (姓).