### PR TITLE
Add missing require_tree

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
+ *= require_tree .
  */
 
 @import "bootstrap-sprockets";


### PR DESCRIPTION
`invite.scss` will not be loaded without `require_tree .`