### PR TITLE
Allow setting arbitrary external testers group

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ To secure your webpage, you only have to set the `ITC_TOKEN` environment variabl
 - `ITC_CLOSED_TEXT` Set this text to temporary disable enrollment of new beta testers
 - `RESTRICTED_DOMAIN` Set this domain (in the format `domain.com`) to restrict users with emails in another domain from signing up. This list supports multiple domains by setting it to a comma delimited list (`domain1.com,domain2.com`)
 - `FASTLANE_ITC_TEAM_NAME` If you're in multiple teams, enter the name of your iTC team here. Make sure it matches.
+- `ITC_EXTERNAL_GROUP` Name of the testers group. When unset, default external group will be used.
 
 ## Custom Domain
 

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -90,7 +90,7 @@ class InviteController < ApplicationController
 
         if apple_id.length > 0
           logger.info "Addding tester to application"
-          app.default_external_group.add_tester!(tester)
+          find_testers_group(app).add_tester!(tester)
           logger.info "Done"
         end
 
@@ -186,5 +186,22 @@ class InviteController < ApplicationController
         end
       end
       return false
+    end
+
+    def find_testers_group app
+      group_name = ENV["ITC_EXTERNAL_GROUP"]
+      if group_name.present?
+        group = Spaceship::TestFlight::Group.find(app_id: app.apple_id,
+                                              group_name: group_name)
+      else
+        group = app.default_external_group
+      end
+
+      return group if group
+
+      Rails.logger.fatal("----------------------------------------------------------------------------")
+      Rails.logger.fatal("No default external group for this iTunes app neither ITC_EXTERNAL_GROUP set")
+      Rails.logger.fatal("----------------------------------------------------------------------------")
+      raise "No default external group for this iTunes app neither ITC_EXTERNAL_GROUP set"
     end
 end


### PR DESCRIPTION
The `app.default_external_group` tends to return `nil`, at lest for my app, so I've added yet another setting to specify desired testers group. I'm pretty fresh to Test Flight, so it's pretty likely that this new setting variable should be renamed. So does verbiage.