### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM heroku/ruby
+WORKDIR /app/user
+CMD bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Use standard Heroku Docker base image. You might probably want to set up automated builds on DockerHub as well.