### PR TITLE
Show basic error message details when boarding fails

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -76,7 +76,7 @@ class InviteController < ApplicationController
       Rails.logger.fatal ex.inspect
       Rails.logger.fatal ex.backtrace.join("\n")
 
-      @message = t(:message_error)
+      @message = [t(:message_error), ex.to_s].join(": ")
       @type = "danger"
     end
 


### PR DESCRIPTION
As per feedback from @steipete, it's time-consuming, and more difficult to open up the server log every time something fails. This way we can show the error message without the stack trace here.

This is just an idea, ideally we might even want to show the stack trace somewhere hidden?

Do we want a way to disable this, as it might reveal more sensitive information?

Feel free to append commits directly to this PR 👍