### PR TITLE
Fix crash when env variables are missing

### DIFF
--- a/app/services/boarding_service.rb
+++ b/app/services/boarding_service.rb
@@ -67,9 +67,9 @@ class BoardingService
     def ensure_values
       error_message = []
 
-      error_message << "Environment variable `ITC_APP_ID` required" if @app_id.empty?
-      error_message << "Environment variable `ITC_USER` or `FASTLANE_USER` required" if @user.empty?
-      error_message << "Environment variable `ITC_PASSWORD` or `FASTLANE_PASSWORD`" if @password.empty?
+      error_message << "Environment variable `ITC_APP_ID` required" if @app_id.blank?
+      error_message << "Environment variable `ITC_USER` or `FASTLANE_USER` required" if @user.blank?
+      error_message << "Environment variable `ITC_PASSWORD` or `FASTLANE_PASSWORD`" if @password.blank?
 
       spaceship = Spaceship::Tunes.login(@user, @password)
       spaceship.select_team


### PR DESCRIPTION
`nil.empty?` crashes, while `nil.blank?` works, however it's only available in Rails, that's why we usually don't use it in the fastlane code base