### PR TITLE
Email variable was not populated before checking RESTRICTED_DOMAIN

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -28,6 +28,10 @@ class InviteController < ApplicationController
       render :index
       return
     end
+    
+    email = params[:email]
+    first_name = params[:first_name]
+    last_name = params[:last_name]
 
     if ENV["RESTRICTED_DOMAIN"]
       domains = ENV["RESTRICTED_DOMAIN"].split(",")
@@ -52,10 +56,6 @@ class InviteController < ApplicationController
       end
     end
     
-    email = params[:email]
-    first_name = params[:first_name]
-    last_name = params[:last_name]
-
     if email.length == 0
       render :index
       return


### PR DESCRIPTION
Found a bug when using the RESTRICTED_DOMAIN environment variable. It attempts to check the email before it is populated with the value from the params. Moved the variables up above that code block. It solves the error when a restricted domain is used.