### PR TITLE
Fix for undefined method error

### DIFF
--- a/app/services/boarding_service.rb
+++ b/app/services/boarding_service.rb
@@ -118,7 +118,7 @@ class BoardingService
         tester = Spaceship::Tunes::Tester::Internal.find_by_app(app.apple_id, email)
         tester ||= Spaceship::Tunes::Tester::External.find_by_app(app.apple_id, email)
       else
-        raise "Account #{current_user.email} doesn't have a role that is allowed to administer app testers, current roles: #{current_user.roles}"
+        raise "Account #{current_user.email_address} doesn't have a role that is allowed to administer app testers, current roles: #{current_user.roles}"
         tester = nil
       end
 


### PR DESCRIPTION
Minor fix for `undefined method error` when attempting to use an iTunes Connect user that doesn't have the correct role.

**Repo Steps**
1. Create an iTunes Connect user with "Developer" Role and set the Boarding env variables to use that user.
2. Attempt to register a new test flight user.
3. Observe following stack trace:

```
#<NoMethodError: undefined method `email' for #<Spaceship::Tunes::Member:0x007fba2965d0e8>>
/Users/dougsuriano/dev/boarding/app/services/boarding_service.rb:121:in `find_app_tester'
/Users/dougsuriano/dev/boarding/app/services/boarding_service.rb:42:in `add_tester'
/Users/dougsuriano/dev/boarding/app/controllers/invite_controller.rb:91:in `create_and_add_tester'
/Users/dougsuriano/dev/boarding/app/controllers/invite_controller.rb:74:in `submit'
```