### PR TITLE
Add optional imprint link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ To secure your webpage, you only have to set the `ITC_TOKEN` environment variabl
 - `ITC_CLOSED_TEXT` Set this text to temporary disable enrollment of new beta testers
 - `RESTRICTED_DOMAIN` Set this domain (in the format `domain.com`) to restrict users with emails in another domain from signing up. This list supports multiple domains by setting it to a comma delimited list (`domain1.com,domain2.com`)
 - `FASTLANE_ITC_TEAM_NAME` If you're in multiple teams, enter the name of your iTC team here. Make sure it matches.
+- `IMPRINT_URL` If you want a link to an imprint to be shown on the invite page.
 
 ## Custom Domain
 

--- a/app.json
+++ b/app.json
@@ -33,6 +33,10 @@
     "GA_PROPERTY_ID": {
       "description": "Optional: Configure Google Analytics to track visitors on your website.",
       "required": false
+    },
+    "IMPRINT_URL": {
+      "description": "Optional: URL to imprint. The link is shown on the invite page.",
+      "required": false
     }
   }
 }

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -2,6 +2,7 @@ require 'spaceship'
 class InviteController < ApplicationController
   before_action :set_app_details
   before_action :check_disabled_text
+  before_action :check_imprint_url
 
   skip_before_filter :verify_authenticity_token
 
@@ -115,6 +116,12 @@ class InviteController < ApplicationController
       if boarding_service.itc_closed_text
         @message = boarding_service.itc_closed_text
         @type = "warning"
+      end
+    end
+
+    def check_imprint_url
+      if boarding_service.imprint_url
+        @imprint_url = boarding_service.imprint_url
       end
     end
 end

--- a/app/services/boarding_service.rb
+++ b/app/services/boarding_service.rb
@@ -16,6 +16,7 @@ class BoardingService
   attr_accessor :is_demo
   attr_accessor :itc_token
   attr_accessor :itc_closed_text
+  attr_accessor :imprint_url
 
   def initialize(app_id: ENV["ITC_APP_ID"],
                    user: ENV["ITC_USER"] || ENV["FASTLANE_USER"],
@@ -31,6 +32,7 @@ class BoardingService
     @is_demo = ENV["ITC_IS_DEMO"]
     @itc_token = ENV["ITC_TOKEN"]
     @itc_closed_text = ENV["ITC_CLOSED_TEXT"]
+    @imprint_url = ENV["IMPRINT_URL"]
 
     ensure_values
   end

--- a/app/views/invite/index.html.erb
+++ b/app/views/invite/index.html.erb
@@ -51,6 +51,9 @@
   <% end %>
 
   <p class="footer">
+    <% if @imprint_url %>
+      <%= link_to t(:imprint), @imprint_url, target: "_blank" %> |
+    <% end %>
     Powered by <a href="https://fastlane.tools" target="_blank">fastlane</a>
   </p>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -36,3 +36,4 @@ de:
   message_email_exists: "E-Mail-Adresse ist bereits registriert"
   message_error: "Ein Fehler ist aufgetreten, bitte kontaktieren Sie den Hersteller der Applikation"
   loading: "Lade"
+  imprint: "Impressum"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,3 +36,4 @@ en:
   message_email_exists: "Email address is already registered"
   message_error: "Something went wrong, please contact the application owner"
   loading: "Loading"
+  imprint: "Imprint"


### PR DESCRIPTION
Due to legal reasons, we have to a link to an imprint on the invite page.
This might also be helpful for other user who want to setup boarding and have similar constraints.