### PR TITLE
Update README.md file for missing other fastlane tools link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/pilot">pilot</a> &bull;
   <b>boarding</b> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/gym">gym</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a>
+  <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/precheck">precheck</a>
 </p>
 
 -------


### PR DESCRIPTION
At now(2017.09.24) Fastlane has tools

- deliver
- snapshot
- frameit
- pem
- sigh
- produce
- cert
- spaceship
- pilot
- gym
- scan

And

- match
- precheck

But now our README.md file missing link for match and precheck.
I think Agile update for document is the most important things in open source project.
So I Added missing link. That's All