### PR TITLE
Check if a tester is already added to the desired group(s)

### DIFF
--- a/app/services/boarding_service.rb
+++ b/app/services/boarding_service.rb
@@ -42,7 +42,9 @@ class BoardingService
     add_tester_response.type = "danger"
 
     tester = find_app_tester(email: email, app: app)
-    if tester
+    if tester # TODO: check what groups this tester needs to be added to
+      # Spaceship::TestFlight::Group.perform_for_groups_in_app(app: app, groups: tester_group_names) - tester.groups
+        
       add_tester_response.message = t(:message_email_exists)
     else
       tester = create_tester(
@@ -51,12 +53,6 @@ class BoardingService
         last_name: last_name,
         app: app
       )
-      if true || testing_is_live? # TODO: remove true and test new train system
-        add_tester_response.message = t(:message_success_live)
-      else
-        add_tester_response.message = t(:message_success_pending)
-      end
-      add_tester_response.type = "success"
     end
 
     begin
@@ -72,6 +68,13 @@ class BoardingService
           Rails.logger.info "Successfully added tester to the default tester group in app: #{app.name}"
         end
       end
+
+      if testing_is_live?
+        add_tester_response.message = t(:message_success_live)
+      else
+        add_tester_response.message = t(:message_success_pending)
+      end
+      add_tester_response.type = "success"
 
     rescue => ex
       Rails.logger.error "Could not add #{tester.email} to app: #{app.name}"

--- a/app/services/boarding_service.rb
+++ b/app/services/boarding_service.rb
@@ -146,13 +146,15 @@ class BoardingService
       raise error_message.join("\n") if error_message.length > 0
     end
 
-    def testing_is_live?
-      app.build_trains.each do |version, train|
-        if train.external_testing_enabled
-          train.builds.each do |build|
-            return true if build.external_testing_enabled
-          end
+    def testing_is_live? # TODO: clean this when Spaceship::TestFlight::BuildTrains has more attributes
+      app.build_trains(platform: 'ios').values.each do |trains|
+        # if train.external_testing_enabled
+        #   train.builds.each do |build|
+        trains.each do |build|
+          return true if build.active?
         end
+        #   end
+        # end
       end
       return false
     end

--- a/app/services/boarding_service.rb
+++ b/app/services/boarding_service.rb
@@ -51,7 +51,7 @@ class BoardingService
         last_name: last_name,
         app: app
       )
-      if testing_is_live?
+      if true || testing_is_live? # TODO: remove true and test new train system
         add_tester_response.message = t(:message_success_live)
       else
         add_tester_response.message = t(:message_success_pending)
@@ -85,18 +85,12 @@ class BoardingService
 
     def create_tester(email: nil, first_name: nil, last_name: nil, app: nil)
       current_user = Spaceship::Members.find(Spaceship::Tunes.client.user)
-      if current_user.admin?
-        tester = Spaceship::Tunes::Tester::External.create!(email: email,
-                                                       first_name: first_name,
-                                                        last_name: last_name)
-        Rails.logger.info "Successfully added tester: #{email} to your account"
-      elsif current_user.app_manager?
-
+      if current_user.admin? || current_user.app_manager?
         Spaceship::TestFlight::Tester.create_app_level_tester(app_id: app.apple_id,
                                                           first_name: first_name,
                                                            last_name: last_name,
                                                                email: email)
-        tester = Spaceship::Tunes::Tester::External.find_by_app(app.apple_id, email)
+        tester = Spaceship::TestFlight::Tester.find(app_id: app.apple_id, email: email)
         Rails.logger.info "Successfully added tester: #{email} to app: #{app.name}"
       else
         raise "Current account doesn't have permission to create a tester"
@@ -110,15 +104,11 @@ class BoardingService
 
     def find_app_tester(email: nil, app: nil)
       current_user = Spaceship::Members.find(Spaceship::Tunes.client.user)
-      if current_user.admin?
-        tester = Spaceship::Tunes::Tester::Internal.find(email)
-        tester ||= Spaceship::Tunes::Tester::External.find(email)
-      elsif current_user.app_manager?
+      if current_user.admin? || current_user.app_manager?
         unless app
-          raise "Account #{current_user.email_address} is only an 'App Manager' and therefore you must also define what app this tester (#{email}) should be added to"
+          raise "You must define what app this tester (#{email}) should be added to"
         end
-        tester = Spaceship::Tunes::Tester::Internal.find_by_app(app.apple_id, email)
-        tester ||= Spaceship::Tunes::Tester::External.find_by_app(app.apple_id, email)
+        tester = Spaceship::TestFlight::Tester.find(app_id: app.apple_id, email: email)
       else
         raise "Account #{current_user.email_address} doesn't have a role that is allowed to administer app testers, current roles: #{current_user.roles}"
         tester = nil


### PR DESCRIPTION
Right now, boarding will display an error message if a tester is already added to an app, but not part of a group yet. In addition, invites are not resent, if the tester is already added to the group.

This PR is a work in progress to resolve these issues.

## Tasks
- [ ] Display the new and old groups to which a tester is added
- [ ] Resend the TestFlight invite if the user has not yet accepted the invite, and display a message
- [ ] Optimization: only add the tester to groups that the tester is not yet a part of

## Addresses
* #180 Email Address Already Registered for New Users + No TestFlight Emails Sent
* #146 Email address already registered
* Feel free to reference other issues here