### PR TITLE
[WIP] Add support for dropdown to select the iTC testing group

### DIFF
--- a/app/services/boarding_service.rb
+++ b/app/services/boarding_service.rb
@@ -37,9 +37,10 @@ class BoardingService
     ensure_values
   end
 
-  def add_tester(email, first_name, last_name)
+  def add_tester(email, first_name, last_name, custom_group = nil)
     add_tester_response = AddTesterResponse.new
     add_tester_response.type = "danger"
+    custom_group ||= tester_group_names
 
     tester = find_app_tester(email: email, app: app)
     if tester
@@ -60,12 +61,12 @@ class BoardingService
     end
 
     begin
-      groups = Spaceship::TestFlight::Group.add_tester_to_groups!(tester: tester, app: app, groups: tester_group_names)
+      groups = Spaceship::TestFlight::Group.add_tester_to_groups!(tester: tester, app: app, groups: custom_group)
       if tester.kind_of?(Spaceship::Tunes::Tester::Internal)
         Rails.logger.info "Successfully added tester to app #{app.name}"
       else
         # tester was added to the group(s) in the above add_tester_to_groups() call, now we need to let the user know which group(s)
-        if tester_group_names
+        if custom_group
           group_names = groups.map(&:name).join(", ")
           Rails.logger.info "Successfully added tester to group(s): #{group_names} in app: #{app.name}"
         else

--- a/app/views/invite/index.html.erb
+++ b/app/views/invite/index.html.erb
@@ -41,6 +41,11 @@
         <% end %>
       <% end %>
 
+      <% if @groups_for_dropdown && @groups_for_dropdown.count > 1 %>
+        <%= label_tag(:group, t(:group)) %>
+        <%= select("groups", "selected", @groups_for_dropdown) %>
+      <% end %>
+
       <br />
       <%= submit_tag t(:get_beta_access), class: 'btn btn-lg btn-primary btn-block', id: "submit" %>
     <% end %>
@@ -86,5 +91,10 @@
       bottom: 10px;
       right: 25px;
     }
+  }
+  select {
+    width: 100%;
+    margin-bottom: 20px;
+    height: 35px;
   }
 </style>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,3 +37,4 @@ en:
   message_error: "Something went wrong, please contact the application owner"
   loading: "Loading"
   imprint: "Imprint"
+  group: "Group"


### PR DESCRIPTION
**Note**: I wasn't able to test this, as I didn't find a way to create a second group. 

This PR adds a functionality to provide a white list of tester groups a user should be able to select from. This is useful in case you have multiple groups, for example `Release Candidates` and `Nightly` and want each user to choose which program they want to be part of. 

The dropdown uses a white-list approach, as many dev teams probably have groups they want to use internally only (or maybe invite-only). This PR also makes sure that the user didn't manually add a new item to the request and try to add themselves by guessing names. 
Also, the dropdown is automatically hidden if no white list is provided, or if there is only group provided. The group names are separated by the `;` character. 

Idea and lobbying by @steipete, :club_mate: works every single time :) 

#### Missing pieces:

- I wasn't able to test this, as I didn't find a way to create a second group.
- Add documentation
- [optional] Add to `app.json`