### PR TITLE
WIP/Propsal for "API-Mode"

### DIFF
--- a/app/controllers/concerns/api_mode.rb
+++ b/app/controllers/concerns/api_mode.rb
@@ -1,0 +1,27 @@
+module ApiMode
+  extend ActiveSupport::Concern
+
+  included do
+    protect_from_forgery with: :null_session
+
+    before_action :cors_preflight_check
+    after_action :cors_set_access_control_headers
+
+    private
+
+      def cors_set_access_control_headers
+        headers["Access-Control-Allow-Origin"] = "*"
+        headers["Access-Control-Allow-Methods"] = "POST, GET, OPTIONS"
+        headers["Access-Control-Allow-Headers"] = "*"
+        headers['Access-Control-Request-Method'] = "*"
+        headers["Access-Control-Max-Age"] = "1728000"
+      end
+
+      def cors_preflight_check
+        if request.method == :options
+          cors_set_access_control_headers
+          render text: "", content_type: "text/plain"
+        end
+      end
+  end
+end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -1,5 +1,7 @@
 require 'spaceship'
 class InviteController < ApplicationController
+  include ApiMode if ENV["API_MODE"] == "enabled"
+
   before_action :set_app_details
   before_action :check_disabled_text
   before_action :check_imprint_url
@@ -29,7 +31,7 @@ class InviteController < ApplicationController
       render :index
       return
     end
-    
+
     email = params[:email]
     first_name = params[:first_name]
     last_name = params[:last_name]
@@ -56,7 +58,7 @@ class InviteController < ApplicationController
         return
       end
     end
-    
+
     if email.length == 0
       render :index
       return


### PR DESCRIPTION
I am using boarding with another UI front end that HTTP Posts the required form data to the boarding app. In order to do so I needed to reconfigure boarding to:

a) disable requiring CSRF tokens
b) setting the required CORS headers on each request

I was wondering weather any1 else is interested in this usage and weather the maintainers would care to support this kind of behavior.

If so I'd offer to provide Docs, refactor it if required, etc. and provide the necessary steps to allow the maintainers to keep this feature maintanable.