### PR TITLE
Fix tests and use web-console for dev only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,9 +34,11 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
-
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+end
+
+group :development do
+  # Access an IRB console on exception pages or by using <%= console %> in views
+  gem 'web-console', '~> 2.0'
 end


### PR DESCRIPTION
Avoiding the error below when running `bundle exec rake` :

```
Web Console is activated in the test environment, which is
usually a mistake. To ensure it's only activated in development
mode, move it to the development group of your Gemfile:

    gem 'web-console', group: :development

If you still want to run it the test environment (and know
what you are doing), put this in your Rails application
configuration:

    config.web_console.development_only = false
```