### PR TITLE
Added Deploy to Azure Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,20 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/precheck">precheck</a>
 </p>
 
--------
+---
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/fastlane/boarding/master/assets/BoardingHuge.png" width="650">
 </p>
 
--------
+---
 
 [![Twitter: @FastlaneTools](https://img.shields.io/badge/contact-@FastlaneTools-blue.svg?style=flat)](https://twitter.com/FastlaneTools)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/fastlane/boarding/blob/master/LICENSE)
 
-
 Get in contact with the developers on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools/)
 
-
--------
+---
 
 <p align="center">
     <a href="#whats-boarding">Why?</a> &bull;
@@ -47,7 +45,7 @@ Get in contact with the developers on Twitter: [@FastlaneTools](https://twitter.
     <a href="#update-to-a-new-version">Update</a>
 </p>
 
--------
+---
 
 <h5 align="center"><code>boarding</code> is part of <a href="https://fastlane.tools">fastlane</a>: connect all deployment tools into one streamlined workflow.</h5>
 
@@ -73,11 +71,17 @@ Thanks to [spaceship.airforce](https://spaceship.airforce) (oh well, I really ta
 
 # Getting Started
 
+Assuming you already have an [Azure](https://www.azure.com/) account follow those steps:
+
+* [![Deploy to Azure](https://azuredeploy.net/deploybutton.svg)](https://deploy.azure.com/?repository=https://github.com/dersia/boarding/blob/master)
+* Enter your iTunes Connect credentials and the bundle identifier of your app. This will all be stored on your own Heroku instance as environment variables
+* It can take up to 5 minutes until everything is loaded.
+
 Assuming you already have a [Heroku](https://www.heroku.com/) account follow those steps:
 
-- [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://www.heroku.com/deploy?template=https://github.com/fastlane/boarding)
-- Enter your iTunes Connect credentials and the bundle identifier of your app. This will all be stored on your own Heroku instance as environment variables
-- Click on `View` once the setup is complete and start sharing the URL
+* [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://www.heroku.com/deploy?template=https://github.com/fastlane/boarding)
+* Enter your iTunes Connect credentials and the bundle identifier of your app. This will all be stored on your own Heroku instance as environment variables
+* Click on `View` once the setup is complete and start sharing the URL
 
 `boarding` does all kinds of magic for you, like fetching the app name and app icon.
 
@@ -95,31 +99,34 @@ If your account is protected using 2-factor author, follow the [2 step verificat
 
 To secure your webpage, you only have to set the `ITC_TOKEN` environment variable to any password.
 
-- You can send your users the link and tell them the password
-- You can send them the direct link including the token like this: https://url.com/?token=[password]
+* You can send your users the link and tell them the password
+* You can send them the direct link including the token like this: https://url.com/?token=[password]
 
 ## Available environment variables
 
 **Required:**
 
-- `ITC_USER` iTunes Connect username
-- `ITC_PASSWORD` iTunes Connect password
-- `ITC_APP_ID` The Apple ID or Bundle Identifier of your app
+* `ITC_USER` iTunes Connect username
+* `ITC_PASSWORD` iTunes Connect password
+* `ITC_APP_ID` The Apple ID or Bundle Identifier of your app
 
 **Optional:**
-- `ITC_TOKEN` Set a password to protect your website from random people signing up
-- `ITC_CLOSED_TEXT` Set this text to temporary disable enrollment of new beta testers
-- `RESTRICTED_DOMAIN` Set this domain (in the format `domain.com`) to restrict users with emails in another domain from signing up. This list supports multiple domains by setting it to a comma delimited list (`domain1.com,domain2.com`)
-- `FASTLANE_ITC_TEAM_NAME` If you're in multiple teams, enter the name of your iTC team here. Make sure it matches.
-- `IMPRINT_URL` If you want a link to an imprint to be shown on the invite page.
+
+* `ITC_TOKEN` Set a password to protect your website from random people signing up
+* `ITC_CLOSED_TEXT` Set this text to temporary disable enrollment of new beta testers
+* `RESTRICTED_DOMAIN` Set this domain (in the format `domain.com`) to restrict users with emails in another domain from signing up. This list supports multiple domains by setting it to a comma delimited list (`domain1.com,domain2.com`)
+* `FASTLANE_ITC_TEAM_NAME` If you're in multiple teams, enter the name of your iTC team here. Make sure it matches.
+* `IMPRINT_URL` If you want a link to an imprint to be shown on the invite page.
 
 ## Custom Domain
 
 With Heroku you can easily use your own domain, follow [this guide](https://devcenter.heroku.com/articles/custom-domains).
 
+With Azure you can easily use your own domain, follow [this guid](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain?toc=%2fazure%2fapp-service%2fcontainers%2ftoc.json)
+
 ## Alternative Setup Options
 
-- Docker image: [emcniece/docker-boarding](https://github.com/emcniece/docker-boarding)
+* Docker image: [emcniece/docker-boarding](https://github.com/emcniece/docker-boarding)
 
 # How does this work?
 
@@ -129,8 +136,8 @@ Using [spaceship.airforce](https://spaceship.airforce) it is possible to manage 
 
 This repository is a simple Rails application with most code in these files:
 
-- [invite_controller.rb](https://github.com/fastlane/boarding/blob/master/app/controllers/invite_controller.rb)
-- [invite/index.html.erb](https://github.com/fastlane/boarding/blob/master/app/views/invite/index.html.erb)
+* [invite_controller.rb](https://github.com/fastlane/boarding/blob/master/app/controllers/invite_controller.rb)
+* [invite/index.html.erb](https://github.com/fastlane/boarding/blob/master/app/views/invite/index.html.erb)
 
 ![BoardingOverview](https://raw.githubusercontent.com/fastlane/boarding/master/assets/BoardingOverview.png)
 
@@ -140,14 +147,14 @@ More information about this automation process can be found [here](https://kraus
 
 If you want to change the design, layout or even add new features:
 
-- Install the [Heroku toolbelt](https://toolbelt.heroku.com/) and `heroku login`
-- Clone your application using `heroku git:clone --app [heroku_app_name]` (it will be an empty repo)
-- `cd [heroku_app_name]`
-- `git pull https://github.com/fastlane/boarding`
-- Modify the content, in particular the files that are described above.
-- Test it locally by running `ITC_USER="email" ITC_... rails s` and opening [http://127.0.0.1:3000](http://127.0.0.1:3000)
-- Commit the changes
-- `git push`
+* Install the [Heroku toolbelt](https://toolbelt.heroku.com/) and `heroku login`
+* Clone your application using `heroku git:clone --app [heroku_app_name]` (it will be an empty repo)
+* `cd [heroku_app_name]`
+* `git pull https://github.com/fastlane/boarding`
+* Modify the content, in particular the files that are described above.
+* Test it locally by running `ITC_USER="email" ITC_... rails s` and opening [http://127.0.0.1:3000](http://127.0.0.1:3000)
+* Commit the changes
+* `git push`
 
 It is recommended to also store your version in your git repo additionally to Heroku.
 
@@ -157,17 +164,49 @@ From time to time there will be updates to `boarding`. There are 2 ways to updat
 
 ### Recommended: Using the terminal
 
-- Install the [Heroku toolbelt](https://toolbelt.heroku.com/) and `heroku login`
-- Clone your application using `heroku git:clone --app [heroku_app_name]` (it will be an empty repo)
-- `cd [heroku_app_name]`
-- `git pull https://github.com/fastlane/boarding`
-- `git push`
+* Install the [Heroku toolbelt](https://toolbelt.heroku.com/) and `heroku login`
+* Clone your application using `heroku git:clone --app [heroku_app_name]` (it will be an empty repo)
+* `cd [heroku_app_name]`
+* `git pull https://github.com/fastlane/boarding`
+* `git push`
 
 ### Using Heroku website
 
-- Delete your application on [heroku.com](https://www.heroku.com/)
-- [Create a new boarding application](https://www.heroku.com/deploy?template=https://github.com/fastlane/boarding)
-- Enter your user credentials again
+* Delete your application on [heroku.com](https://www.heroku.com/)
+* [Create a new boarding application](https://www.heroku.com/deploy?template=https://github.com/fastlane/boarding)
+* Enter your user credentials again
+
+### Using Azure website
+
+* Navigate to the [Azure Portal](https://portal.azure.com/)
+* Login and navigate to your WebApp
+* On `Overview` hit the restart button
+
+# Managing Azure version
+
+If you installed `boarding` using the `deploy to Azure` button, `boarding` will be deployed in an Azure WebApp for containers.
+This means that azure is running the [docker-version](https://github.com/emcniece/docker-boarding) of `boarding`.
+
+### Setting optional parameters in Azure
+
+In order to set the optional parameters for `boarding` follow these steps:
+
+* Navigate to the [Azure Portal](https://portal.azure.com/)
+* Login and navigate to your WebApp
+* Under `Settings` click `Application settings`
+* Click the link `+ Add new setting` and add the the optional parameter i.e. `ITC_CLOSED_TEXT` = `We are closed!`
+* Hit `Save` and navigate to `Overview`
+* On `Overview` hit the restart button
+
+### Troubleshoot boarding on Azure
+
+When you run `boarding` on Azure, it could happen that you run into an HttpStatus 503 showing `Service Unavailable`
+There can be multiple reasons for that:
+
+* `boarding` isn't yet fully loaded. Wait a few minutes hit refresh.
+* The provided parameters are wrong (`ITC_USER`, `ITC_PASSWORD`, `ITC_APP_ID`). Please go to the settings in Azure and check if they are right.
+
+For further troubleshooting, please got to [Azure App Service on Linux FAQ](https://docs.microsoft.com/en-us/azure/app-service/containers/app-service-linux-faq)
 
 ##### [Like this tool? Be the first to know about updates and new fastlane tools](https://tinyletter.com/krausefx)
 
@@ -176,9 +215,11 @@ From time to time there will be updates to `boarding`. There are 2 ways to updat
 Special thanks to [@lee_moonan](https://twitter.com/lee_moonan) for designing the awesome logo.
 
 # Code of Conduct
+
 Help us keep `boarding` open and inclusive. Please read and follow our [Code of Conduct](https://github.com/fastlane/code-of-conduct).
 
 # License
+
 This project is licensed under the terms of the MIT license. See the LICENSE file.
 
 > This project and all fastlane tools are in no way affiliated with Apple Inc. This project is open source under the MIT license, which means you have full access to the source code and can modify it to fit your own needs. All fastlane tools run on your own computer or server, so your credentials or other sensitive information will never leave your own computer. You are responsible for how you use fastlane tools.

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,177 @@
+{
+  "$schema":
+    "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "webapp_name": {
+      "defaultValue": "myWebApp",
+      "type": "string",
+      "metadata": {
+        "description":
+          "name of your WebApp in Azure. This is also used as the url part (https://<webapp_name>.azurewebsites.net/) so make sure it is unique  (Required)"
+      }
+    },
+    "webapp_plan": {
+      "type": "string",
+      "defaultValue": "B1",
+      "allowedValues": ["B1", "B2", "B3", "S1", "S2", "S3"],
+      "metadata": {
+        "description":
+          "WebApp plan size B(asic)1 - 3, S(tandard)1 -3  (Required)"
+      }
+    },
+    "ITC_USER": {
+      "defaultValue": null,
+      "type": "string",
+      "metadata": {
+        "description": "iTunes Connect username (Required)"
+      }
+    },
+    "ITC_PASSWORD": {
+      "defaultValue": null,
+      "type": "securestring",
+      "metadata": {
+        "description": "iTunes Connect password  (Required)"
+      }
+    },
+    "ITC_APP_ID": {
+      "defaultValue": null,
+      "type": "string",
+      "metadata": {
+        "description":
+          "The Apple ID or Bundle Identifier of your app  (Required)"
+      }
+    }
+  },
+  "variables": {
+    "webapp_plan_name": "[concat(parameters('webapp_name'), 'plan')]",
+    "ProjectTag": "fastlane_boarding",
+    "webapp_plan_tier":
+      "[if(equals(first(parameters('webapp_plan')), 'B'), 'Basic', if(equals(first(parameters('webapp_plan')), 'S'), 'Standard', 'ERROR'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2016-09-01",
+      "name": "[variables('webapp_plan_name')]",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "Project": "[variables('ProjectTag')]"
+      },
+      "kind": "linux",
+      "sku": {
+        "name": "[parameters('webapp_plan')]",
+        "tier": "[variables('webapp_plan_tier')]",
+        "size": "[parameters('webapp_plan')]",
+        "family": "[first(parameters('webapp_plan'))]",
+        "capacity": 1
+      },
+      "properties": {
+        "name": "[variables('webapp_plan_name')]",
+        "perSiteScaling": false,
+        "targetWorkerCount": 0,
+        "targetWorkerSizeId": 0,
+        "reserved": true
+      },
+      "dependsOn": []
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2016-08-01",
+      "name": "[parameters('webapp_name')]",
+      "location": "[resourceGroup().location]",
+      "kind": "app,linux",
+      "resources": [
+        {
+          "apiVersion": "2016-08-01",
+          "name": "appsettings",
+          "type": "config",
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/Sites', parameters('webapp_name'))]"
+          ],
+          "tags": {
+            "Project": "[variables('ProjectTag')]"
+          },
+          "properties": {
+            "WEBSITES_PORT": "3000",
+            "WEBSITES_ENABLE_APP_SERVICE_STORAGE": "false",
+            "DOCKER_ENABLE_CI": "false",
+            "ITC_USER": "[parameters('ITC_USER')]",
+            "ITC_PASSWORD": "[parameters('ITC_PASSWORD')]",
+            "ITC_APP_ID": "[parameters('ITC_APP_ID')]"
+          }
+        }
+      ],
+      "tags": {
+        "Project": "[variables('ProjectTag')]"
+      },
+      "properties": {
+        "enabled": true,
+        "serverFarmId":
+          "[resourceId('Microsoft.Web/serverfarms', variables('webapp_plan_name'))]",
+        "reserved": true,
+        "siteConfig": {
+          "linuxFxVersion": "DOCKER|emcniece/docker-boarding",
+          "alwaysOn": true,
+          "numberOfWorkers": 1,
+          "defaultDocuments": [
+            "Default.htm",
+            "Default.html",
+            "Default.asp",
+            "index.htm",
+            "index.html",
+            "iisstart.htm",
+            "default.aspx",
+            "index.php",
+            "hostingstart.html"
+          ],
+          "netFrameworkVersion": "v4.6",
+          "requestTracingEnabled": false,
+          "remoteDebuggingEnabled": false,
+          "remoteDebuggingVersion": "VS2017",
+          "httpLoggingEnabled": true,
+          "logsDirectorySizeLimit": 35,
+          "detailedErrorLoggingEnabled": true,
+          "scmType": "None",
+          "use32BitWorkerProcess": true,
+          "managedPipelineMode": "Integrated",
+          "virtualApplications": [
+            {
+              "virtualPath": "/",
+              "physicalPath": "site\\wwwroot",
+              "preloadEnabled": true
+            }
+          ],
+          "winAuthAdminState": 0,
+          "winAuthTenantState": 0,
+          "customAppPoolIdentityAdminState": false,
+          "customAppPoolIdentityTenantState": false,
+          "runtimeADUser": null,
+          "runtimeADUserPassword": null,
+          "loadBalancing": "LeastRequests",
+          "routingRules": [],
+          "experiments": {
+            "rampUpRules": []
+          },
+          "autoHealEnabled": false,
+          "vnetName": "",
+          "siteAuthEnabled": false
+        },
+        "clientAffinityEnabled": true,
+        "clientCertEnabled": false,
+        "hostNamesDisabled": false,
+        "containerSize": 0,
+        "dailyMemoryTimeQuota": 0
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('webapp_plan_name'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "webapp_name": {
+      "type": "string",
+      "value": "[parameters('webapp_name')]"
+    }
+  }
+}


### PR DESCRIPTION
I added a deploy to Azure button, for those who don't want to use Heroku.
This will deploy the docker-version of `boarding` as an WebApp in Azure.

I also added some trouble shooting and more information to the readme.md