### PR TITLE
added the variable in the heroku deployment env (app.json) and update…

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ To secure your webpage, you only have to set the `ITC_TOKEN` environment variabl
 * `ITC_CLOSED_TEXT` Set this text to temporary disable enrollment of new beta testers
 * `RESTRICTED_DOMAIN` Set this domain (in the format `domain.com`) to restrict users with emails in another domain from signing up. This list supports multiple domains by setting it to a comma delimited list (`domain1.com,domain2.com`)
 * `FASTLANE_ITC_TEAM_NAME` If you're in multiple teams, enter the name of your iTC team here. Make sure it matches.
+* `FASTLANE_SESSION` You need to provide a [pregenerated session](https://docs.fastlane.tools/best-practices/continuous-integration/#spaceauth) via fastlane spaceauth if you have 2-factor authentication enabled and want to use any actions that communicates with App Store Connect.
 * `IMPRINT_URL` If you want a link to an imprint to be shown on the invite page.
 
 ## Custom Domain

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To secure your webpage, you only have to set the `ITC_TOKEN` environment variabl
 * `ITC_CLOSED_TEXT` Set this text to temporary disable enrollment of new beta testers
 * `RESTRICTED_DOMAIN` Set this domain (in the format `domain.com`) to restrict users with emails in another domain from signing up. This list supports multiple domains by setting it to a comma delimited list (`domain1.com,domain2.com`)
 * `FASTLANE_ITC_TEAM_NAME` If you're in multiple teams, enter the name of your iTC team here. Make sure it matches.
-* `FASTLANE_SESSION` You need to provide a [pregenerated session](https://docs.fastlane.tools/best-practices/continuous-integration/#spaceauth) via fastlane spaceauth if you have 2-factor authentication enabled and want to use any actions that communicates with App Store Connect.
+* `FASTLANE_SESSION` You need to provide a [pregenerated session](https://docs.fastlane.tools/best-practices/continuous-integration/#spaceauth) via `fastlane spaceauth` if you have 2-factor authentication enabled and want to use any actions that communicates with App Store Connect.
 * `IMPRINT_URL` If you want a link to an imprint to be shown on the invite page.
 
 ## Custom Domain

--- a/app.json
+++ b/app.json
@@ -23,7 +23,7 @@
       "required": false
     },
     "FASTLANE_SESSION": {
-      "description": "Optional: You need to provide a pregenerated session via fastlane spaceauth if you have 2-factor authentication enabled and want to use any actions that communicates with App Store Connect.",
+      "description": "Optional: You need to provide a pregenerated session via `fastlane spaceauth` if you have 2-factor authentication enabled and want to use any actions that communicates with App Store Connect.",
       "required": false
     },
     "ITC_APP_TESTER_GROUPS": {

--- a/app.json
+++ b/app.json
@@ -22,6 +22,10 @@
       "description": "Optional: If you're in multiple teams, enter the name of your iTC team here. Make sure it matches.",
       "required": false
     },
+    "FASTLANE_SESSION": {
+      "description": "Optional: You need to provide a pregenerated session via fastlane spaceauth if you have 2-factor authentication enabled and want to use any actions that communicates with App Store Connect.",
+      "required": false
+    },
     "ITC_APP_TESTER_GROUPS": {
       "description": "Optional: The groups you want the invited to be placed in",
       "required": false


### PR DESCRIPTION
…d the readme with a link to the docs on how to generate the session


### Checklist
- [ *] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ *] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ *] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [* ] I've updated the documentation if necessary.

### Motivation and Context
The "deploy to Heroku" button does not work if the iTunes connect account is configured for 2FA. This is because the FASTLANE_SESSION variable was not configured as an input variable for Heroku deployment, so it just fails. Existing solutions involve downloading the repo and "manually" deploying to Heroku, rendering the deploy to Heroku button useless. 

https://github.com/fastlane/boarding/issues/242

### Description
Have added FASLTANE_SESSION and a description for this variable to app.json which is the file used to configure the heroku deploy. It's set as an optional variable. 
Added this variable to the readme, on line 119 with a link to the docs that describes how to generate the session.

### Testing Steps
I used this to deploy myself by opening up this link: https://www.heroku.com/deploy?template=https://github.com/coderbec/boarding/tree/2FA-enablement (this is what a deploy to Heroku button links to but configured for my fork)

